### PR TITLE
Reverse the order of JSON imports to prefer the core python library

### DIFF
--- a/django_extras/core/validators.py
+++ b/django_extras/core/validators.py
@@ -1,9 +1,9 @@
 # Convenience imports
 from django.core.validators import *  # noqa
 try:
-    from django.utils import simplejson as json
-except ImportError:
     import json
+except ImportError:
+    from django.utils import simplejson as json
 import six
 from django.utils.translation import ugettext_lazy as _
 

--- a/django_extras/db/models/fields/jsonfield.py
+++ b/django_extras/db/models/fields/jsonfield.py
@@ -1,8 +1,8 @@
 import six
 try:
-    from django.utils import simplejson as json
-except ImportError:
     import json
+except ImportError:
+    from django.utils import simplejson as json
 from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
 from django.db import models


### PR DESCRIPTION
...if it exists.  If not, fall back on django.utils.simplejson.

This was already mentioned in Issue #3. The problem is that your solution is looking for an ImportError where a deprecation warning simply prints to the console. By simply swapping the order that the Django-extras tries to import, we have a solution that avoid deprecation warnings and is backwards compatible.

By the way, your django_extras\http__init__.py was already in the correct import order.

Please pip deploy as well.
