### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,11 @@ covered by the core Django framework.
     support), the `BitBucket <https://bitbucket.org/timsavage/django-extras>`_ repository may not contain the latest
     code.
 
-.. image:: https://pypip.in/license/django-extras/badge.png
+.. image:: https://img.shields.io/pypi/l/django-extras.svg
     :target: https://pypi.python.org/pypi/django-extras/
     :alt: License
 
-.. image:: https://pypip.in/v/django-extras/badge.png
+.. image:: https://img.shields.io/pypi/v/django-extras.svg
     :target: https://pypi.python.org/pypi/django-extras/
 
 .. image:: https://travis-ci.org/timsavage/django-extras.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-extras))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-extras`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.